### PR TITLE
feat: add canDrop

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Minoru Okuyama <okuyama@analogic.jp>
+Ben Heidemann <ben.heidemann@medayo.com>

--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ return (
 );
 ```
 
+Note that this will replace the default behaviour which will not take any action when a drop would not result in a change to the tree structure or when dropping on a node would result in a malformed tree e.g. dropping a droppable node on itself as shown in the below graphic. Therefore, if you pass this callback, you may need to handle such cases.
+
+![malformed tree](https://user-images.githubusercontent.com/3772820/113640360-3b6ac780-96b6-11eb-83a4-b73971de8878.gif)
+
 ### Component Styling
 
 You are free to define the styling of individual nodes in the tree in your Render props, but the rest of the tree can be styled by specifying the CSS class name for the `classes` property.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ you can use the `data` property.
 |render|function|yes||The render function of each node.<br>Please refer to the [Render prop](#Render-prop) section for more details about the render functions.|
 |dragPreviewRender|function|no|undefined|Render function for customizing the drag preview.<br>See the [Dragging Preview](#Dragging-Preview) section for more information on customizing the drag preview.|
 |onDrop|function|yes||Callback function for when the state of the tree is changed.<br>The new data is passed as the argument.<br>See the [onDrop callback](#onDrop-callback) section for more information.|
+|canDrop|function|no|undefined|Callback function which should return true or false depending on if a give node should be droppable onto another node.<br>The callback will receive the current tree and an options object which is the same as the one which would be passed to the onDrop callback.<br>See the [canDrop callback](#canDrop-callback) section for more information.|
 |sort|function \| boolean|no|true|Passing false will disable sorting. Alternatively, pass a callback to use in place of the default sort callback.|
 |initialOpen|boolean \| array | no | false | If true, all parent nodes will be initialized to the open state.<br>If an array of node IDs is passed instead of the boolean value, only the specified node will be initialized in the open state. |
 
@@ -281,6 +282,29 @@ The arguments passed to the onDrop callback function are as follows
 |options.dragSource|object|node item of the dragging source|
 |options.dropTarget|object \| undefined|node item of the drop destination.<br>If the drop destination is the root node, it will be `undefined`|
 
+### canDrop callback
+
+This callback should return true if the node being dragged can be dropped onto a given node. If it returns false and the user drops the dragged node, no action will be taken and the [onDrop callback](#onDrop-callback) will not be fired.
+
+This callback accepts the same parameters as the onDrop callback except that the first parameter will be the current tree.
+
+```jsx
+const canDrop = (currentTree, {dragSourceId, dropTargetId, dragSource, dropTarget}) => {
+  return true;
+
+  // or 
+
+  return false;
+};
+
+return (
+  <Tree
+    {...props}
+    tree={treeData}
+    canDrop={canDrop}
+  />
+);
+```
 
 ### Component Styling
 

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -25,7 +25,7 @@ export const Container: React.FC<Props> = (props) => {
   }
 
   const view = [...groups, ...templates];
-  const [isOver, drop] = useDropContainer(context.tree, context.onDrop);
+  const [isOver, drop] = useDropContainer(props.parentId, context.tree, context.onDrop, context.canDrop);
   const classes = context.classes;
 
   let className = "";

--- a/src/Node.tsx
+++ b/src/Node.tsx
@@ -22,7 +22,7 @@ export const Node: React.FC<Props> = (props) => {
   }
 
   const [isDragging, drag, preview] = useDragNode(item, ref);
-  const [isOver, drop] = useDropNode(props.id, context.tree, context.onDrop);
+  const [isOver, drop] = useDropNode(item, context.tree, context.onDrop, context.canDrop);
 
   if (item.droppable) {
     drop(drag(ref));

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -7,7 +7,6 @@ import { mutateTree, getTreeItem } from "./utils";
 import { useOpenIdsHelper } from "./hooks";
 import { TreeContext, OpenIdsHandlers, TreeProps } from "./types";
 
-
 const Context = createContext<TreeContext>({} as TreeContext);
 
 const Tree = forwardRef<OpenIdsHandlers, TreeProps>((props, ref) => {

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -31,6 +31,15 @@ type Props = {
       dropTarget: NodeModel | undefined;
     }
   ) => void;
+  canDrop?: (
+    tree: NodeModel[],
+    options: {
+      dragSourceId: NodeModel["id"];
+      dropTargetId: NodeModel["id"];
+      dragSource: NodeModel | undefined;
+      dropTarget: NodeModel | undefined;
+    }
+  ) => boolean;
   sort?: SortCallback;
 };
 
@@ -47,6 +56,8 @@ const Tree = forwardRef<OpenIdsHandlers, Props>((props, ref) => {
     closeAll: () => handleCloseAll(),
   }));
 
+  const canDropCallback = props.canDrop;
+
   return (
     <Context.Provider
       value={{
@@ -59,6 +70,15 @@ const Tree = forwardRef<OpenIdsHandlers, Props>((props, ref) => {
             dragSource: getTreeItem(props.tree, id),
             dropTarget: getTreeItem(props.tree, parentId),
           }),
+        canDrop: canDropCallback
+          ? (id, parentId) =>
+              canDropCallback(props.tree, {
+                dragSourceId: id,
+                dropTargetId: parentId,
+                dragSource: getTreeItem(props.tree, id),
+                dropTarget: getTreeItem(props.tree, parentId),
+              })
+          : undefined,
         onToggle: handleToggle,
         sort: props.sort,
       }}

--- a/src/__tests__/Tree.test.tsx
+++ b/src/__tests__/Tree.test.tsx
@@ -100,8 +100,8 @@ const dragAndDrop = (src: Element, dst: Element) => {
 };
 
 describe("Tree", () => {
-  const renderTree = () => {
-    const { container } = render(<TestTree />);
+  const renderTree = (props: Partial<TreeProps> = {}) => {
+    const { container } = render(<TestTree {...props} />);
     return container;
   };
 

--- a/src/__tests__/Tree.test.tsx
+++ b/src/__tests__/Tree.test.tsx
@@ -181,6 +181,69 @@ describe("Tree", () => {
     ).toBe(true);
   });
 
+  test("drag and drop: File 1-2 to root node with falsy canDrop should not call onDrop", () => {
+    const onDrop = jest.fn();
+    const canDrop = jest.fn().mockReturnValue(false);
+
+    renderTree({
+      onDrop,
+      canDrop
+    });
+
+    fireEvent.click(screen.getAllByText("[+]")[0]);
+
+    expect(
+      screen.getAllByRole("list")[1].contains(screen.getByText("File 1-2"))
+    ).toBe(true);
+
+    const src = screen.getAllByRole("listitem")[2];
+    const dst = screen.getAllByRole("list")[0];
+
+    dragAndDrop(src, dst);
+
+    expect(canDrop).toHaveBeenCalled();
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  test("drag and drop: Folder 2 to Folder 2 should not call onDrop", () => {
+    const onDrop = jest.fn();
+
+    renderTree({
+      onDrop
+    });
+
+    fireEvent.click(screen.getAllByText("[+]")[0]);
+
+    const src = screen.getAllByRole("listitem")[3];
+    const dst = src;
+
+    dragAndDrop(src, dst);
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  test("drag and drop: Folder 2 to Folder 2 with canDrop callback", () => {
+    const onDrop = jest.fn();
+    const canDrop = jest.fn().mockReturnValue(true);
+
+    renderTree({
+      onDrop,
+      canDrop
+    });
+
+    fireEvent.click(screen.getAllByText("[+]")[0]);
+
+    const src = screen.getAllByRole("listitem")[3];
+    const dst = src;
+
+    dragAndDrop(src, dst);
+
+    expect(canDrop).toHaveBeenCalled();
+
+    expect(onDrop).toHaveBeenCalled();
+  });
+
   test("show drag preview while dragging list item", () => {
     renderTree();
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,8 +20,10 @@ import {
 } from "./types";
 
 export const useDropContainer = (
+  parentId: NodeModel["id"],
   tree: NodeModel[],
-  onDrop: DropHandler
+  onDrop: DropHandler,
+  canDrop: CanDropHandler | undefined
 ): [boolean, DragElementWrapper<HTMLElement>] => {
   const [{ isOver }, drop] = useDrop({
     accept: ItemTypes.TREE_ITEM,
@@ -31,7 +33,10 @@ export const useDropContainer = (
       }
     },
     canDrop: (item: DragItem) => {
-      const dragItem = tree.find((node) => node.id === item.id);
+      const dragItem = tree.find((node) => node.id === item.id) as NodeModel;
+      if (canDrop) {
+        return canDrop(dragItem.id, parentId)
+      }
       return dragItem === undefined ? false : dragItem.parent !== 0;
     },
     collect: (monitor) => ({

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,6 +15,7 @@ import {
   DragLayerMonitorProps,
   DragOverProps,
   ToggleHandler,
+  CanDropHandler,
 } from "./types";
 
 export const useDropContainer = (
@@ -99,18 +100,24 @@ const isAncestor = (
 };
 
 export const useDropNode = (
-  id: NodeModel["id"],
+  item: NodeModel,
   tree: NodeModel[],
-  onDrop: DropHandler
+  onDrop: DropHandler,
+  canDrop: CanDropHandler | undefined
 ): [boolean, DragElementWrapper<HTMLElement>] => {
   const [{ isOver }, drop] = useDrop({
     accept: ItemTypes.TREE_ITEM,
-    drop: (item: DragItem, monitor) => {
+    drop: (dragItem: DragItem, monitor) => {
       if (monitor.isOver({ shallow: true })) {
-        onDrop(item.id, id);
+        onDrop(dragItem.id, item.id);
       }
     },
-    canDrop: (item: DragItem) => isDroppable(tree, item.id, id),
+    canDrop: (dragItem: DragItem) => {
+      if (canDrop) {
+        return canDrop(dragItem.id, item.id);
+      }
+      return isDroppable(tree, dragItem.id, item.id);
+    },
     collect: (monitor) => ({
       isOver: monitor.isOver({ shallow: true }) && monitor.canDrop(),
     }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,6 @@ export type TreeProps = {
       dropTarget: NodeModel | undefined;
     }
   ) => boolean;
-  sort?: SortCallback;
+  sort?: SortCallback | boolean;
   initialOpen?: InitialOpen;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,11 @@ export type DropHandler = (
   parent: NodeModel["id"]
 ) => void;
 
+export type CanDropHandler = (
+  id: NodeModel["id"],
+  parent: NodeModel["id"]
+) => boolean;
+
 export type Classes = {
   root?: string;
   container?: string;
@@ -51,6 +56,7 @@ export type TreeContext = {
   render: NodeRender;
   dragPreviewRender?: DragPreviewRender;
   onDrop: DropHandler;
+  canDrop?: CanDropHandler;
   onToggle: ToggleHandler;
   sort?: SortCallback | boolean;
 };


### PR DESCRIPTION
Closes #21 

Adds a property called "onDrop" to the Tree component which allows the user to customise when and when not to allow dropping on nodes.