### PR TITLE
fix: incorrect parameters passed to the canDrop callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.4.3
+
+_July 17, 2021_
+
+### Fixed
+
+- incorrect parameters passed to the canDrop callback.
+- mouse cursor becomes the default pointer when hovering over an area that cannot be dropped.
+
 ## 1.4.2
 
 _July 08, 2021_

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@minoru/react-dnd-treeview",
   "description": "A draggable / droppable React-based treeview component.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/hooks/useDropContainer.ts
+++ b/src/hooks/useDropContainer.ts
@@ -15,15 +15,18 @@ export const useDropContainer = (
         context.onDrop(item.id, context.rootId);
       }
     },
-    canDrop: (item: DragItem) => {
-      const { tree, canDrop } = context;
-      const dragItem = tree.find((node) => node.id === item.id);
+    canDrop: (item: DragItem, monitor) => {
+      if (monitor.isOver({ shallow: true })) {
+        const { canDrop } = context;
 
-      if (canDrop && dragItem) {
-        return canDrop(dragItem.id, parentId);
+        if (canDrop) {
+          return canDrop(item.id, parentId);
+        }
+
+        return item === undefined ? false : item.parent !== 0;
       }
 
-      return dragItem === undefined ? false : dragItem.parent !== 0;
+      return false;
     },
     collect: (monitor) => ({
       isOver: monitor.isOver({ shallow: true }) && monitor.canDrop(),

--- a/src/hooks/useDropNode.ts
+++ b/src/hooks/useDropNode.ts
@@ -16,14 +16,18 @@ export const useDropNode = (
         context.onDrop(dragItem.id, item.id);
       }
     },
-    canDrop: (dragItem: DragItem) => {
-      const { tree, canDrop } = context;
+    canDrop: (dragItem: DragItem, monitor) => {
+      if (monitor.isOver({ shallow: true })) {
+        const { tree, canDrop } = context;
 
-      if (canDrop) {
-        return canDrop(dragItem.id, item.id);
+        if (canDrop) {
+          return canDrop(dragItem.id, item.id);
+        }
+
+        return isDroppable(tree, dragItem.id, item.id);
       }
 
-      return isDroppable(tree, dragItem.id, item.id);
+      return false;
     },
     collect: (monitor) => ({
       isOver: monitor.isOver({ shallow: true }) && monitor.canDrop(),


### PR DESCRIPTION
mouse cursor becomes the default pointer when hovering over an area that cannot be dropped.