### PR TITLE
Allow open specific node list

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -15,6 +15,7 @@ import {
   DragControlState,
   OpenIdsHandlers,
   TreeProps,
+  NodeModel,
 } from "./types";
 
 const TreeContext = createContext<TreeState>({} as TreeState);
@@ -23,10 +24,12 @@ const DragControlContext = createContext<DragControlState>(
 );
 
 const Tree = forwardRef<OpenIdsHandlers, TreeProps>((props, ref) => {
-  const [openIds, { handleToggle, handleCloseAll, handleOpenAll }] =
+  const [openIds, { handleToggle, handleCloseAll, handleOpenAll, handleOpen }] =
     useOpenIdsHelper(props.tree, props.initialOpen);
 
   useImperativeHandle(ref, () => ({
+    open: (targetIds: NodeModel["id"] | NodeModel["id"][]) =>
+      handleOpen(targetIds),
     openAll: () => handleOpenAll(),
     closeAll: () => handleCloseAll(),
   }));

--- a/src/hooks/useOpenIdsHelper.ts
+++ b/src/hooks/useOpenIdsHelper.ts
@@ -10,6 +10,7 @@ export const useOpenIdsHelper = (
     handleToggle: ToggleHandler;
     handleCloseAll: () => void;
     handleOpenAll: () => void;
+    handleOpen: (targetIds: NodeModel["id"] | NodeModel["id"][]) => void;
   }
 ] => {
   let initialOpenIds: NodeModel["id"][] = [];
@@ -44,5 +45,24 @@ export const useOpenIdsHelper = (
     [tree]
   );
 
-  return [openIds, { handleToggle, handleCloseAll, handleOpenAll }];
+  const handleOpen = useCallback(
+    (targetIds: NodeModel["id"] | NodeModel["id"][]) =>
+      setOpenIds(
+        [
+          ...openIds,
+          ...tree
+            .filter(
+              (node) =>
+                node.droppable &&
+                (Array.isArray(targetIds)
+                  ? targetIds.includes(node.id)
+                  : node.id === targetIds)
+            )
+            .map((node) => node.id),
+        ].filter((value, index, self) => self.indexOf(value) === index)
+      ),
+    [tree, openIds]
+  );
+
+  return [openIds, { handleToggle, handleCloseAll, handleOpenAll, handleOpen }];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,7 @@ export type DragOverProps = {
 };
 
 export type OpenIdsHandlers = {
+  open(targetIds: NodeModel["id"] | NodeModel["id"][]): void;
   openAll(): void;
   closeAll(): void;
 };


### PR DESCRIPTION
This is the cleanest and leanest drag'n'drop treeview I've ever used. However, I have found that only being able to call `.openAll()`  or initialise the tree with all nodes opened is insufficient for my needs.

This change adds an `.open()` method to the Tree's imperative handle, allowing the user to call `treeRef.current?.open(myNodeId)` or `treeRef.current?.open([myNodeId, myOtherNodeId])` to add specific nodes to the `openIds`.