### PR TITLE
Add cancelOnDropOutside flag to improve UX on manual sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React DnD TreeView
 
-A draggable / droppable React-based treeview component.  
+A draggable / droppable React-based treeview component.
 You can use render props to create each node freely.
 
 ![react-dnd-treeview](https://user-images.githubusercontent.com/3772820/98293395-94441000-1ff1-11eb-81db-b84c31b03c6b.gif)
@@ -22,7 +22,7 @@ Some of the examples below use Material-UI components, but TreeView does not dep
 - Auto expand with drag over node ([JavaScript](https://codesandbox.io/s/auto-expand-with-drag-over-node-js-zksyi) | [TypeScript](https://codesandbox.io/s/opening-and-closing-all-nodes-ts-forked-7rcdk))
 - Initialize with open parents ([JavaScript](https://codesandbox.io/s/initialize-with-open-parents-js-hk45o) | [TypeScript](https://codesandbox.io/s/initialize-with-open-parents-ts-9nkw3))
 - Editable nodes ([JavaScript](https://codesandbox.io/s/editable-js-m25be) | [TypeScript](https://codesandbox.io/s/editable-ts-cl3wi))
-- Manual sort with placeholder ([JavaScript](https://codesandbox.io/s/placeholder-js-xhu2j) | [TypeScript](https://codesandbox.io/s/placeholder-ts-w71l5))
+- Manual sort with placeholder ([JavaScript](https://codesandbox.io/s/placeholder-js-forked-wtiet) | [TypeScript](https://codesandbox.io/s/placeholder-ts-forked-ebupf))
 - Add, remove, duplicate nodes ([JavaScript](https://codesandbox.io/s/add-delete-copy-js-4x4l8) | [TypeScript](https://codesandbox.io/s/add-delete-copy-ts-owgqb))
 
 ## Getting Started
@@ -110,7 +110,7 @@ The minimal data structure for representing the tree is shown in the following e
 
 ### Optional data
 
-If you want to pass custom properties to each node's rendering,  
+If you want to pass custom properties to each node's rendering,
 you can use the `data` property.
 
 ```json
@@ -192,7 +192,8 @@ you can use the `data` property.
 | insertDroppableFirst | boolean             | no       | true      | Specifies whether droppable nodes should be placed first in the list of child nodes.                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | placeholderRender    | function            | no       | undefined | Render function for the drop destination placeholder. By default, placeholder is not displayed.<br>See the [Manual sort with placeholder](#Manual-sort-with-placeholder) section for more information on using placeholder.                                                                                                                                                                                                                                                                                |
 | placeholderComponent | string              | no       | li        | HTML tag for placeholder.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| dropTargetOffset     | number              | no       | 0         | Effective drop range of a dropable node. It is specified in pixels from the top or bottom of the node.<br>Used to insert a node anywhere using placeholders.<br><br>See the [Manual sort with placeholder placeholder](#Manual-sort-with-placeholder) section for more information on using placeholder.                                                                                                                                                                                                   |
+| cancelOnDropOutside | boolean             | no       | true      | Specifies whether a drop outside of the tree is considered valid or not. By default dropping is only valid inside the tree component.<br>This can be used if you want to force the drop to happen at the position where the placeholder currently is, even if the cursor is not hovering the tree anymore.<br>See the [Manual sort with placeholder](#Manual-sort-with-placeholder) section for more information on using placeholder.                                                                                                                                                                                                                                                                                                    |
+| dropTargetOffset     | number              | no       | 0         | Effective drop range of a droppable node. It is specified in pixels from the top or bottom of the node.<br>Used to insert a node anywhere using placeholders.<br><br>See the [Manual sort with placeholder](#Manual-sort-with-placeholder) section for more information on using placeholder.                                                                                                                                                                                                   |
 | initialOpen          | boolean \| array    | no       | false     | If true, all parent nodes will be initialized to the open state.<br>If an array of node IDs is passed instead of the boolean value, only the specified node will be initialized in the open state.                                                                                                                                                                                                                                                                                                         |
 | rootProps            | object              | no       | undefined | Properties to be passed to the root element (by default, `ul` tag), excluding the `ref` and `role` property.                                                                                                                                                                                                                                                                                                                                                                                               |
 
@@ -230,11 +231,11 @@ The arguments passed to the render function are as follows
 
 ### Dragging Preview
 
-By default, the drag preview is a screenshot of a DOM node.  
+By default, the drag preview is a screenshot of a DOM node.
 The `dragPreviewRender` property allows you to display a custom React component instead of a screenshot.
 
-NOTE:  
-The default preview is not displayed on touch devices.  
+NOTE:
+The default preview is not displayed on touch devices.
 Therefore, if you want to support touch devices, please define a custom preview in `dragPreviewRender`.
 
 ```jsx
@@ -322,8 +323,8 @@ const canDrop = (
 return <Tree {...props} tree={treeData} canDrop={canDrop} />;
 ```
 
-NOTE:  
-When overriding the default rules by returning true or false, be careful of inconsistencies in the tree structure.  
+NOTE:
+When overriding the default rules by returning true or false, be careful of inconsistencies in the tree structure.
 For example, if you allow dropping from a parent node to a child node as shown in the figure below, inconsistency will occur and the tree will collapse.
 
 ![malformed tree](https://user-images.githubusercontent.com/3772820/114326837-9d717400-9b71-11eb-91cf-c762c4ab7461.gif)

--- a/src/__tests__/Tree.test.tsx
+++ b/src/__tests__/Tree.test.tsx
@@ -689,4 +689,68 @@ describe("Tree", () => {
 
     expect(isDragging).toBe(false);
   });
+
+  describe("cancelOnDropOutside prop", () => {
+    const dragAndDropOutside = (draggedElement: Element, lastTargetDraggedOver: Element) => {
+      fireEvent.dragStart(draggedElement);
+      fireEvent.dragEnter(lastTargetDraggedOver);
+      fireEvent.dragOver(lastTargetDraggedOver);
+      // There is no drop event when dragging to outside of the droppable area
+      fireEvent.dragLeave(lastTargetDraggedOver);
+      fireEvent.dragEnd(draggedElement);
+      fireEvent.dragEnd(window);
+    };
+
+    describe("when flag is true (default)", () => {
+      test("drag and drop: File 3 dropped outside of droppable area does not call onDrop callback", () => {
+        const onDrop = jest.fn();
+
+        renderTree({ onDrop });
+
+        const items = screen.getAllByRole("listitem");
+        const src = items[2];
+        const lastTargetDraggedOver = items[0];
+
+        dragAndDropOutside(src, lastTargetDraggedOver);
+
+        expect(onDrop).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when flag is false", () => {
+      test("drag and drop: File 3 dropped outside of droppable area calls onDrop callback", () => {
+        const onDrop = jest.fn();
+
+        renderTree({
+          onDrop,
+          cancelOnDropOutside: false,
+        });
+
+        const items = screen.getAllByRole("listitem");
+        const src = items[2];
+        const lastTargetDraggedOver = items[0];
+
+        dragAndDropOutside(src, lastTargetDraggedOver);
+
+        expect(onDrop).toHaveBeenCalledTimes(1);
+      });
+
+      test("drag and drop: File 3 dropped inside of droppable area calls onDrop callback", () => {
+        const onDrop = jest.fn();
+
+        renderTree({
+          onDrop,
+          cancelOnDropOutside: false,
+        });
+
+        const items = screen.getAllByRole("listitem");
+        const src = items[2];
+        const lastTargetDraggedOver = items[0];
+
+        dragAndDrop(src, lastTargetDraggedOver);
+
+        expect(onDrop).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });

--- a/src/__tests__/utils.test.tsx
+++ b/src/__tests__/utils.test.tsx
@@ -163,6 +163,7 @@ describe("utilities test", () => {
       placeholderComponent: "li",
       sort: false,
       insertDroppableFirst: true,
+      cancelOnDropOutside: true,
       dropTargetOffset: 0,
       initialOpen: false,
       openIds: [],

--- a/src/hooks/useDragNode.ts
+++ b/src/hooks/useDragNode.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import {
   useDrag,
   DragElementWrapper,
@@ -8,6 +8,7 @@ import {
 import { ItemTypes } from "../ItemTypes";
 import { NodeModel, DragSourceElement } from "../types";
 import { useTreeContext } from "../hooks";
+import { PlaceholderContext } from "../providers";
 
 let dragSourceElement: DragSourceElement = null;
 
@@ -20,6 +21,7 @@ export const useDragNode = <T>(
   DragElementWrapper<DragPreviewOptions>
 ] => {
   const treeContext = useTreeContext<T>();
+  const placeholderContext = useContext(PlaceholderContext);
 
   const register = (e: DragEvent | TouchEvent): void => {
     const { target } = e;
@@ -66,6 +68,20 @@ export const useDragNode = <T>(
       }
 
       return true;
+    },
+    end: (item, monitor) => {
+      const { cancelOnDropOutside } = treeContext;
+      const { dropTargetId, index } = placeholderContext;
+
+      if (cancelOnDropOutside || monitor.didDrop()) return;
+
+      if (
+        item?.id !== undefined &&
+        dropTargetId !== undefined &&
+        index !== undefined
+      ) {
+        treeContext.onDrop(item.id, dropTargetId, index);
+      }
     },
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),

--- a/src/providers/TreeProvider.tsx
+++ b/src/providers/TreeProvider.tsx
@@ -44,6 +44,7 @@ export const TreeProvider = <T extends unknown>(
     placeholderComponent: "li",
     sort: true,
     insertDroppableFirst: true,
+    cancelOnDropOutside: true,
     dropTargetOffset: 0,
     initialOpen: false,
     ...props,

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,7 @@ export type TreeState<T> = TreeStateBase<T> & {
   placeholderComponent: ElementType;
   sort: SortCallback<T> | boolean;
   insertDroppableFirst: boolean;
+  cancelOnDropOutside: boolean;
   dropTargetOffset: number;
   initialOpen: InitialOpen;
   openIds: NodeModel["id"][];
@@ -162,6 +163,7 @@ export type TreeProps<T> = TreeStateBase<T> & {
   placeholderComponent?: ElementType;
   sort?: SortCallback<T> | boolean;
   insertDroppableFirst?: boolean;
+  cancelOnDropOutside?: boolean;
   dropTargetOffset?: number;
   initialOpen?: InitialOpen;
   onChangeOpen?: ChangeOpenHandler;


### PR DESCRIPTION
When Tree component is used to manual sort items, the user might drag items outside of the droppable area -- especially when trying to move it to the top or the bottom of the list. If we restrict the drop to only the tree area, we might have some weird behaviors, like rendering the placeholder somewhere, but not accepting a drop when the user releases
the mouse button for example.

The default is still only allowing drop inside the tree area, but by setting `cancelOnDropOutside` as `false` we allow drops outside of the tree whenever there's a placeholder being rendered.

This is an example of the original issue:

https://user-images.githubusercontent.com/836386/150551213-773a2696-ac69-47b9-abdd-c17523f4936f.mov


