### PR TITLE
feat: new util `getParents`

### DIFF
--- a/src/utils/getParents.test.ts
+++ b/src/utils/getParents.test.ts
@@ -1,0 +1,21 @@
+import { getParents } from "./getParents";
+import treeData from "../stories/assets/sample-default.json";
+
+describe("getParents", () => {
+  test("get parental nodes by id", () => {
+    let parentalIds = getParents(treeData, 1).map((n) => n.id);
+
+    expect(parentalIds.includes(0)).toBe(false);
+    expect(parentalIds.includes(2)).toBe(false);
+    expect(parentalIds.length).toBe(0);
+
+    parentalIds = getParents(treeData, 3).map((n) => n.id);
+
+    expect(parentalIds.includes(1)).toBe(true);
+    expect(parentalIds.length).toBe(1);
+
+    parentalIds = getParents(treeData, 6).map((n) => n.id);
+
+    expect(parentalIds.length).toBe(2);
+  });
+});

--- a/src/utils/getParents.ts
+++ b/src/utils/getParents.ts
@@ -1,0 +1,15 @@
+import { NodeModel } from "~/types";
+
+/** Get all parental nodes of the given node id. */
+export function getParents<T = unknown>(
+  treeData: NodeModel<T>[],
+  id: NodeModel["id"]
+) {
+  let parents: NodeModel<T>[] = [];
+  let node = treeData.find((el) => el.id === id);
+  while (node) {
+    node = treeData.find((el) => el.id === node!.parent);
+    if (node) parents.push(node);
+  }
+  return parents;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,5 +8,6 @@ export { getDropTarget } from "./getDropTarget";
 export { getDestIndex } from "./getDestIndex";
 export { getModifiedIndex } from "./getModifiedIndex";
 export { getDescendants } from "./getDescendants";
+export { getParents } from "./getParents";
 export { getBackendOptions } from "./getBackendOptions";
 export { isNodeModel } from "./isNodeModel";


### PR DESCRIPTION
Use case: when enter a page, we want to auto expand the parent node of the last selected node, then the `getParents` util will be helpful to dig the parental nodes.