### PR TITLE
add relativeIndex to onDrop callback

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -40,7 +40,7 @@ export const Container = <T,>(props: Props): ReactElement => {
 
   if (
     props.parentId === treeContext.rootId &&
-    isDroppable<T>(dragSource, treeContext.rootId, treeContext)
+    isDroppable<T>(dragSource, treeContext.rootId, treeContext, null)
   ) {
     drop(ref);
   }

--- a/src/Node.tsx
+++ b/src/Node.tsx
@@ -34,7 +34,14 @@ export const Node = <T,>(props: Props): ReactElement | null => {
 
   useDragHandle(containerRef, handleRef, drag);
 
-  if (isDroppable(dragSource, props.id, treeContext)) {
+  if (
+    isDroppable(
+      dragSource,
+      props.id,
+      treeContext,
+      placeholderContext.index ?? null
+    )
+  ) {
     drop(containerRef);
   }
 

--- a/src/hooks/useDropNode.ts
+++ b/src/hooks/useDropNode.ts
@@ -46,7 +46,12 @@ export const useDropNode = <T>(
           return false;
         }
 
-        return isDroppable(dragItem, dropTarget.id, treeContext);
+        return isDroppable(
+          dragItem,
+          dropTarget.id,
+          treeContext,
+          dropTarget.index
+        );
       }
 
       return false;
@@ -65,7 +70,7 @@ export const useDropNode = <T>(
 
         if (
           dropTarget === null ||
-          !isDroppable(dragItem, dropTarget.id, treeContext)
+          !isDroppable(dragItem, dropTarget.id, treeContext, dropTarget.index)
         ) {
           hidePlaceholder();
           return;

--- a/src/hooks/useDropRoot.ts
+++ b/src/hooks/useDropRoot.ts
@@ -37,7 +37,19 @@ export const useDropRoot = <T>(
           return false;
         }
 
-        return isDroppable(dragItem, rootId, treeContext);
+        const dropTarget = getDropTarget<T>(
+          dragItem,
+          ref.current,
+          monitor,
+          treeContext
+        );
+
+        return isDroppable(
+          dragItem,
+          rootId,
+          treeContext,
+          dropTarget?.index ?? 0
+        );
       }
 
       return false;
@@ -57,7 +69,7 @@ export const useDropRoot = <T>(
 
         if (
           dropTarget === null ||
-          !isDroppable(dragItem, rootId, treeContext)
+          !isDroppable(dragItem, rootId, treeContext, null)
         ) {
           hidePlaceholder();
           return;

--- a/src/providers/TreeProvider.tsx
+++ b/src/providers/TreeProvider.tsx
@@ -116,14 +116,19 @@ export const TreeProvider = <T,>(props: Props<T>): ReactElement => {
       }
     },
     canDrop: canDropCallback
-      ? (dragSourceId, dropTargetId) =>
-          canDropCallback(props.tree, {
+      ? (dragSourceId, dropTargetId, index) => {
+          const options: DropOptions<T> = {
             dragSourceId: dragSourceId ?? undefined,
             dropTargetId,
             dragSource: monitor.getItem(),
             dropTarget: getTreeItem(props.tree, dropTargetId),
             monitor,
-          })
+          };
+          if (props.sort === false) {
+            options.relativeIndex = index ?? undefined;
+          }
+          return canDropCallback(props.tree, options);
+        }
       : undefined,
     canDrag: canDragCallback
       ? (id) => canDragCallback(getTreeItem(props.tree, id))

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,8 @@ export type DropHandler<T> = (
 
 export type CanDropHandler = (
   dragSourceId: NodeModel["id"] | null,
-  dropTargetId: NodeModel["id"]
+  dropTargetId: NodeModel["id"],
+  index: number | null
 ) => boolean | void;
 
 export type CanDragHandler = (id: NodeModel["id"]) => boolean;

--- a/src/utils/getDropTarget.ts
+++ b/src/utils/getDropTarget.ts
@@ -111,6 +111,7 @@ export const getDropTarget = <T>(
     context
   );
 
+  const outerIndex = getOuterIndex(node, nodeEl, monitor);
   if (!list) {
     if (hoverPosition === "middle") {
       return {
@@ -119,9 +120,7 @@ export const getDropTarget = <T>(
       };
     }
 
-    if (isDroppable(dragSource, node.parent, context)) {
-      const outerIndex = getOuterIndex(node, nodeEl, monitor);
-
+    if (isDroppable(dragSource, node.parent, context, outerIndex)) {
       if (outerIndex === null) {
         return null;
       }
@@ -135,9 +134,7 @@ export const getDropTarget = <T>(
     return null;
   } else {
     if (hoverPosition === "upper") {
-      if (isDroppable(dragSource, node.parent, context)) {
-        const outerIndex = getOuterIndex(node, nodeEl, monitor);
-
+      if (isDroppable(dragSource, node.parent, context, outerIndex)) {
         if (outerIndex === null) {
           return null;
         }

--- a/src/utils/isDroppable.test.tsx
+++ b/src/utils/isDroppable.test.tsx
@@ -31,51 +31,51 @@ describe("isDroppable", () => {
       dataTransfer: {} as DataTransfer,
     };
 
-    expect(isDroppable(treeData[6], 7, treeContext)).toBe(false);
-    expect(isDroppable(treeData[6], 1, treeContext)).toBe(true);
-    expect(isDroppable(treeData[0], 1, treeContext)).toBe(false);
-    expect(isDroppable(treeData[3], 5, treeContext)).toBe(false);
-    expect(isDroppable(treeData[6], 0, treeContext)).toBe(false);
-    expect(isDroppable(treeData[1], 0, treeContext)).toBe(true);
-    expect(isDroppable(null, 0, treeContext)).toBe(true);
-    expect(isDroppable(null, 1, treeContext)).toBe(true);
-    expect(isDroppable(null, 2, treeContext)).toBe(false);
-    expect(isDroppable(nativeDragSource, 0, treeContext)).toBe(true);
-    expect(isDroppable(nativeDragSource, 1, treeContext)).toBe(true);
-    expect(isDroppable(nativeDragSource, 2, treeContext)).toBe(false);
+    expect(isDroppable(treeData[6], 7, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[6], 1, treeContext, null)).toBe(true);
+    expect(isDroppable(treeData[0], 1, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[3], 5, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[6], 0, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[1], 0, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 0, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 1, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 2, treeContext, null)).toBe(false);
+    expect(isDroppable(nativeDragSource, 0, treeContext, null)).toBe(true);
+    expect(isDroppable(nativeDragSource, 1, treeContext, null)).toBe(true);
+    expect(isDroppable(nativeDragSource, 2, treeContext, null)).toBe(false);
 
     treeContext.canDrop = () => {
       return false;
     };
 
-    expect(isDroppable(treeData[6], 7, treeContext)).toBe(false);
-    expect(isDroppable(treeData[6], 1, treeContext)).toBe(false);
-    expect(isDroppable(treeData[0], 1, treeContext)).toBe(false);
-    expect(isDroppable(treeData[3], 5, treeContext)).toBe(false);
-    expect(isDroppable(treeData[6], 0, treeContext)).toBe(false);
-    expect(isDroppable(treeData[1], 0, treeContext)).toBe(false);
-    expect(isDroppable(null, 0, treeContext)).toBe(true);
-    expect(isDroppable(null, 1, treeContext)).toBe(true);
-    expect(isDroppable(null, 2, treeContext)).toBe(false);
-    expect(isDroppable(nativeDragSource, 0, treeContext)).toBe(false);
-    expect(isDroppable(nativeDragSource, 1, treeContext)).toBe(false);
-    expect(isDroppable(nativeDragSource, 2, treeContext)).toBe(false);
+    expect(isDroppable(treeData[6], 7, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[6], 1, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[0], 1, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[3], 5, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[6], 0, treeContext, null)).toBe(false);
+    expect(isDroppable(treeData[1], 0, treeContext, null)).toBe(false);
+    expect(isDroppable(null, 0, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 1, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 2, treeContext, null)).toBe(false);
+    expect(isDroppable(nativeDragSource, 0, treeContext, null)).toBe(false);
+    expect(isDroppable(nativeDragSource, 1, treeContext, null)).toBe(false);
+    expect(isDroppable(nativeDragSource, 2, treeContext, null)).toBe(false);
 
     treeContext.canDrop = () => {
       return true;
     };
 
-    expect(isDroppable(treeData[6], 7, treeContext)).toBe(true);
-    expect(isDroppable(treeData[6], 1, treeContext)).toBe(true);
-    expect(isDroppable(treeData[0], 1, treeContext)).toBe(true);
-    expect(isDroppable(treeData[3], 5, treeContext)).toBe(true);
-    expect(isDroppable(treeData[6], 0, treeContext)).toBe(true);
-    expect(isDroppable(treeData[1], 0, treeContext)).toBe(true);
-    expect(isDroppable(null, 0, treeContext)).toBe(true);
-    expect(isDroppable(null, 1, treeContext)).toBe(true);
-    expect(isDroppable(null, 2, treeContext)).toBe(false);
-    expect(isDroppable(nativeDragSource, 0, treeContext)).toBe(true);
-    expect(isDroppable(nativeDragSource, 1, treeContext)).toBe(true);
-    expect(isDroppable(nativeDragSource, 2, treeContext)).toBe(true);
+    expect(isDroppable(treeData[6], 7, treeContext, null)).toBe(true);
+    expect(isDroppable(treeData[6], 1, treeContext, null)).toBe(true);
+    expect(isDroppable(treeData[0], 1, treeContext, null)).toBe(true);
+    expect(isDroppable(treeData[3], 5, treeContext, null)).toBe(true);
+    expect(isDroppable(treeData[6], 0, treeContext, null)).toBe(true);
+    expect(isDroppable(treeData[1], 0, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 0, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 1, treeContext, null)).toBe(true);
+    expect(isDroppable(null, 2, treeContext, null)).toBe(false);
+    expect(isDroppable(nativeDragSource, 0, treeContext, null)).toBe(true);
+    expect(isDroppable(nativeDragSource, 1, treeContext, null)).toBe(true);
+    expect(isDroppable(nativeDragSource, 2, treeContext, null)).toBe(true);
   });
 });

--- a/src/utils/isDroppable.ts
+++ b/src/utils/isDroppable.ts
@@ -5,7 +5,8 @@ import { isNodeModel } from "./isNodeModel";
 export const isDroppable = <T>(
   dragSource: NodeModel<T> | NativeDragItem | null,
   dropTargetId: NodeModel["id"],
-  treeContext: TreeState<T>
+  treeContext: TreeState<T>,
+  index: number | null
 ): boolean => {
   const { tree, rootId, canDrop } = treeContext;
 
@@ -27,8 +28,7 @@ export const isDroppable = <T>(
     const dragSourceId = isNodeModel<T>(dragSource) ? dragSource.id : null;
 
     if (canDrop) {
-      const result = canDrop(dragSourceId, dropTargetId);
-
+      const result = canDrop(dragSourceId, dropTargetId, index);
       if (result !== undefined) {
         return result;
       }


### PR DESCRIPTION
This adds the relativeIndex property to the `onDrop` callback.
Closes #196 