### PR TITLE
fix: hide placeholder when there are no targets

### DIFF
--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -26,13 +26,16 @@ export const Placeholder = <T,>(props: Props): ReactElement | null => {
     return null;
   }
 
+
   const visible =
     props.dropTargetId === placeholderContext.dropTargetId &&
     (props.index === placeholderContext.index ||
       (props.index === undefined &&
         props.listCount === placeholderContext.index));
 
-  if (!visible) {
+  const targetIds = monitor.getTargetIds();
+
+  if (!visible || !targetIds.length) {
     return null;
   }
 

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -26,7 +26,6 @@ export const Placeholder = <T,>(props: Props): ReactElement | null => {
     return null;
   }
 
-
   const visible =
     props.dropTargetId === placeholderContext.dropTargetId &&
     (props.index === placeholderContext.index ||


### PR DESCRIPTION
Hi! First of all, thanks so much for for this library, it's really awesome, tremendous work!

I hope this proposal makes sense. It's aimed to improve the UX of the drag and drop in a specific scenario.

### Problem

When using the custom placeholder, there is a case in which you still see it rendered but you can't actually drop the item being dragged. That happens when you try to drag any item at the very top or bottom of the tree. If your cursor goes outside the bounds of the container, the placeholder is still there, hinting that the item will be dropped right there, but in reality if you drop it nothing happens... it's misleading because the placeholder is there, but the item cannot be dropped.


https://github.com/minop1205/react-dnd-treeview/assets/1586378/ffab0175-fca3-4988-aecf-33d67c6f7030


### Solution

What I'm proposing is just to hide the placeholder when there are no targets. I don't know if this is the correct solution technically speaking but I believe it's the correct one in terms of UX. Happy to change the implementation as you see fit. Any feedback also very welcome. Thanks!


https://github.com/minop1205/react-dnd-treeview/assets/1586378/d409892c-e888-4d25-b3d1-feea666f4b1c

