### PR TITLE
Fixed: Incorrect element detection for `dropTarget` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 3.5.2
+
+_Apr 21, 2025_
+
+### Fixed
+
+- Incorrect element detection for `dropTarget` class.
+
 ## 3.5.0
 
 _Jan 13, 2025_

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@minoru/react-dnd-treeview",
   "description": "A draggable / droppable React-based treeview component.",
-  "version": "3.5.0",
+  "version": "3.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/utils/getDropTarget.ts
+++ b/src/utils/getDropTarget.ts
@@ -72,6 +72,11 @@ const getHoverPosition = <T>(
 ): VerticalPosition => {
   const bbox = el.getBoundingClientRect();
   const offsetY = context.dropTargetOffset;
+
+  if (offsetY === 0) {
+    return "middle";
+  }
+
   const upSideY = bbox.top + offsetY;
   const lowerSideY = bbox.bottom - offsetY;
 


### PR DESCRIPTION
#235 

If the pixel ratio of the executing device is greater than 1, or if a 0.5px margin is applied to the tree, the correct drop target may not be obtained, so this part of the process has been corrected.